### PR TITLE
fix(pgtest): fix callback query call

### DIFF
--- a/lib/pgtest.js
+++ b/lib/pgtest.js
@@ -88,7 +88,7 @@ function PgMock() {
     self.check = function () {
         self.checkCalled = true;
         while (self.queryQueue.length != 0) {
-            let query = self.queryQueue.shift();
+            var query = self.queryQueue.shift();
             if (self.expectQueue.length === 0) {
                 throw new AssertionError('Unexpected query: ' + query[0]);
             }

--- a/lib/pgtest.js
+++ b/lib/pgtest.js
@@ -87,13 +87,13 @@ function PgMock() {
 
     self.check = function () {
         self.checkCalled = true;
-        self.queryQueue.forEach(function (query) {
+        while (self.queryQueue.length != 0) {
+            let query = self.queryQueue.shift();
             if (self.expectQueue.length === 0) {
                 throw new AssertionError('Unexpected query: ' + query[0]);
             }
-
             self.expectQueue.shift().run(query);
-        });
+        }
 
         if (!self.doneCalled) {
             throw new AssertionError('Done was not called');


### PR DESCRIPTION
There is a problem when you want to write unit test where callback function uses the client to perform query again. The forEach loop over the queryQueue and does not take into account query pushed during callback execution.

Switch to a while loop to bypass this issue.